### PR TITLE
Hide dep that are only for compatibility

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -3,6 +3,8 @@ Version:
 Date:
   Features:
     - Add setting to customize robot by craft recipe.
+  Changes:
+    - Compatibility dependencies are now hidden
 ---------------------------------------------------------------------------------------------------
 Version: 0.9.3
 Date: 12. 03. 2022

--- a/src/info.json
+++ b/src/info.json
@@ -9,7 +9,7 @@
     "factorio_version": "1.1",
     "dependencies": [
         "base >= 1.1.0",
-        "?bobelectronics >= 0.18",
-        "?IndustrialRevolution >= 1.0"
+        "(?) bobelectronics >= 0.18",
+        "(?) IndustrialRevolution >= 1.0"
     ]
 }


### PR DESCRIPTION
Feel free to not accept, that just a little quality of life feature of factorio, I think it's make sense for this case. Having two incompatible mod as optional dependencies could be misleading for the user [doc](https://wiki.factorio.com/Tutorial:Mod_structure#Dependency).