### PR TITLE
Unlock robotics-related shortcuts when first tier technology is unlocked

### DIFF
--- a/src/data-updates.lua
+++ b/src/data-updates.lua
@@ -1,0 +1,20 @@
+-- Unlock robotics/blueprint-related shortcuts when the first tier
+-- early construction technology is researched. Particularly useful
+-- for personal roboport toggle shortcut.
+
+local robotics_shortcuts = {
+    "copy",
+    "cut",
+    "give-blueprint",
+    "give-blueprint-book",
+    "give-deconstruction-planner",
+    "give-upgrade-planner",
+    "import-string",
+    "paste",
+    "toggle-personal-roboport",
+    "undo",
+}
+
+for _, shortcut in ipairs(robotics_shortcuts) do
+    data.raw["shortcut"][shortcut].technology_to_unlock = "early-construction-light-armor"
+end


### PR DESCRIPTION
The purpose of this pull request is to fix the problem of robotics-related shortcuts being unavailable to player when the early construction robots are researched in new game installation (with no player data/config).

The shortcuts are normally unlocked across the game instance  configuration (via `player-data.json`) when technologies such as `personal-roboport-equipment` and `construction-robotics` are researched. The PR simply changes the technology dependency to use Early Construction technologies instead.